### PR TITLE
Use preprocessors.register instead of (deprecated) add.

### DIFF
--- a/markdown_include/include.py
+++ b/markdown_include/include.py
@@ -55,9 +55,7 @@ class MarkdownInclude(Extension):
             self.setConfig(key, value)
 
     def extendMarkdown(self, md, md_globals):
-        md.preprocessors.add(
-            'include', IncludePreprocessor(md,self.getConfigs()),'_begin'
-        )
+        md.preprocessors.register(IncludePreprocessor(md,self.getConfigs()), 'include', 101)
 
 
 class IncludePreprocessor(Preprocessor):


### PR DESCRIPTION
Use preprocessors.register instead of (deprecated) add. Also sets priority to 101 (same as mdx_include). 

This is needed so that the execution order can be controlled in a better way. 