### PR TITLE
Fix error when including files without newlines

### DIFF
--- a/markdown_include/include.py
+++ b/markdown_include/include.py
@@ -111,13 +111,13 @@ class IncludePreprocessor(Preprocessor):
                         # Strip the newline, and optionally increase header depth
                         if self.inheritHeadingDepth or self.headingOffset:
                             if HEADING_SYNTAX.search(text[i]):
-                                text[i] = text[i][0:-1]
+                                text[i] = text[i].rstrip('\n')
                                 if self.inheritHeadingDepth:
                                     text[i] = bonusHeading + text[i]
                                 if self.headingOffset:
                                     text[i] = '#' * self.headingOffset + text[i]
                         else:
-                            text[i] = text[i][0:-1]
+                            text[i] = text[i].rstrip('\n')
                             
                     text[0] = line_split[0] + text[0]
                     text[-1] = text[-1] + line_split[2]


### PR DESCRIPTION
The last character of each line is being chipped off, so as to
remove the newline character. But when working with files
without any newlines, this chips off a significant character.

This commit fixes this problem.