### PR TITLE
Fix deprecation warning in Python-Markdown 3.x

### DIFF
--- a/markdown_include/include.py
+++ b/markdown_include/include.py
@@ -54,7 +54,7 @@ class MarkdownInclude(Extension):
         for key, value in configs.items():
             self.setConfig(key, value)
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         md.preprocessors.register(IncludePreprocessor(md,self.getConfigs()), 'include', 101)
 
 


### PR DESCRIPTION
Fixes the following warning when using Python-Markdown 3.x:
`DeprecationWarning: The 'md_globals' parameter of 'markdown_include.include.MarkdownInclude.extendMarkdown' is deprecated.`

Changelog mentioning the signature change:
https://python-markdown.github.io/change_log/release-3.0/#md_globals-keyword-deprecated-from-extension-api