### PR TITLE
Indented included source gets indented

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Markdown is being called. If you would like to change the directory relative to
 which paths are evaluated, then this can be done by specifying the extension
 setting ``base_path``.
 
+If there are leading tabs and spaces before the include statement, 
+all the lines of the included file get prepended the same number of tabs, 
+so includes to indented sections get automatically indented.
+
 ## Configuration
 
 The following settings can be specified when initialising the plugin.

--- a/markdown_include/include.py
+++ b/markdown_include/include.py
@@ -121,7 +121,7 @@ class IncludePreprocessor(Preprocessor):
                             text[i] = text[i].rstrip('\r\n')
                             
                     text[0] = line_split[0] + text[0]
-                    text[-1] = text[-1] + line_split[2]
+                    text[-1] = text[-1] + line_split[-1]
                     lines = lines[:loc] + text + lines[loc+1:]
                     break
                     

--- a/markdown_include/include.py
+++ b/markdown_include/include.py
@@ -29,7 +29,7 @@ from codecs import open
 from markdown.extensions import Extension
 from markdown.preprocessors import Preprocessor
 
-INC_SYNTAX = re.compile(r'\{!\s*(.+?)\s*!\}')
+INC_SYNTAX = re.compile(r'(\w+)\{!\s*(.+?)\s*!\}')
 HEADING_SYNTAX = re.compile( '^#+' )
 
 
@@ -83,7 +83,8 @@ class IncludePreprocessor(Preprocessor):
                 m = INC_SYNTAX.search(line)
 
                 if m:
-                    filename = m.group(1)
+                    tabs = m.group(1)
+                    filename = m.group(2)
                     filename = os.path.expanduser(filename)
                     if not os.path.isabs(filename):
                         filename = os.path.normpath(
@@ -92,6 +93,8 @@ class IncludePreprocessor(Preprocessor):
                     try:
                         with open(filename, 'r', encoding=self.encoding) as r:
                             text = r.readlines()
+                            if len(tabs):
+                                text = [tabs+line for line in text]
                             
                     except Exception as e:
                         if not self.throwException:

--- a/markdown_include/include.py
+++ b/markdown_include/include.py
@@ -29,7 +29,7 @@ from codecs import open
 from markdown.extensions import Extension
 from markdown.preprocessors import Preprocessor
 
-INC_SYNTAX = re.compile(r'(\s*)\{!\s*(.+?)\s*!\}')
+INC_SYNTAX = re.compile(r'([ \t]*)\{!\s*(.+?)\s*!\}')
 HEADING_SYNTAX = re.compile( '^#+' )
 
 

--- a/markdown_include/include.py
+++ b/markdown_include/include.py
@@ -29,7 +29,7 @@ from codecs import open
 from markdown.extensions import Extension
 from markdown.preprocessors import Preprocessor
 
-INC_SYNTAX = re.compile(r'(\w+)\{!\s*(.+?)\s*!\}')
+INC_SYNTAX = re.compile(r'(\s*)\{!\s*(.+?)\s*!\}')
 HEADING_SYNTAX = re.compile( '^#+' )
 
 


### PR DESCRIPTION
Consider the following situation:
```markdown
=== "source"
    ` ` `python
    {!my_source.py!}
    ` ` `
```
and 
```python
print('Hello, world!')
```
Here we'd expect
```markdown
=== "source"
    ` ` `python
    print('Hello, world!')
    ` ` `
```
That is, every line of `my_source.py` gets as many tabs and spaces as many is leading the inclusion tag.

This pull request enables this inclusion mode.