### PR TITLE
✨ Add support for specifying lines and line ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,30 @@ Markdown is being called. If you would like to change the directory relative to
 which paths are evaluated, then this can be done by specifying the extension
 setting ``base_path``.
 
+### Line Ranges
+
+You can also define specific lines or line ranges to include by specifying `lines`:
+
+```Markdown
+{!filename!lines=1  3 8-10  2}
+```
+
+`lines` takes a sequence of integers separated by spaces (one or more), or it can also
+take line ranges specified with a start line and an end line separated by a dash (`-`).
+
+In the example above, it would read the file called `filename` and include the lines
+`1`, `3`, `8`, `9`, `10`, `2`.
+
+Notice that line `9` was not explicitly set. But it was still included as part of the
+range `8-10`.
+
+Also, notice that line `2` is set *after* the range `8-10`. This means that the
+line `2` in `filename` will be included *after* (below) the range `8-10`.
+
+You can use this to include lines in a different order than the original file. But it
+also means that if you want to preserve the original order, you have to pay attention
+to the order in which you specify the lines.
+
 ## Configuration
 
 The following settings can be specified when initialising the plugin.

--- a/markdown_include/include.py
+++ b/markdown_include/include.py
@@ -29,7 +29,7 @@ from codecs import open
 from markdown.extensions import Extension
 from markdown.preprocessors import Preprocessor
 
-INC_SYNTAX = re.compile(r'\{!\s*(.+?)\s*!\}')
+INC_SYNTAX = re.compile(r'{!\s*(.+?)\s*!((\blines\b)=([0-9 -]+))?\}')
 HEADING_SYNTAX = re.compile( '^#+' )
 
 
@@ -91,7 +91,7 @@ class IncludePreprocessor(Preprocessor):
                         )
                     try:
                         with open(filename, 'r', encoding=self.encoding) as r:
-                            text = r.readlines()
+                            original_text = r.readlines()
                             
                     except Exception as e:
                         if not self.throwException:
@@ -101,6 +101,46 @@ class IncludePreprocessor(Preprocessor):
                             break
                         else:
                             raise e
+                    if m.group(2) is None:
+                        text = original_text
+                    else:
+                        lines_str = m.group(4)
+                        lines_blocks = lines_str.split()
+                        wanted_lines = []
+                        for block in lines_blocks:
+                            if "-" in block:
+                                start, end = block.strip().split("-")
+                                current_start = int(start)
+                                current_end = int(end)
+                                if not len(original_text) >= current_end:
+                                    current_end = len(original_text)
+                                    print(
+                                        f"Warning: line range: {block} ending in "
+                                        f"line: {end} is larger than file: {filename} "
+                                        f"using end: {current_end}"
+                                    )
+                                if not current_start <= current_end:
+                                    current_start = max(current_end - 1, 1)
+                                    print(
+                                        f"Warning: in line range: {block} "
+                                        f"the start line: {start} is not "
+                                        f"smaller than the end line: {current_end} "
+                                        f"using start: {current_start}"
+                                    )
+                                
+                                wanted_lines.extend(original_text[current_start-1:current_end])
+                            else:
+                                wanted_line = int(block.strip())
+                                current_line = wanted_line
+                                if current_line > len(original_text):
+                                    current_line = len(original_text)
+                                    print(
+                                        f"Warning: line: {wanted_line} is larger than "
+                                        f"file: {filename} using end: {current_line}"
+                                    )
+                                wanted_lines.append(original_text[current_line-1])
+                        text = wanted_lines
+
 
                     line_split = INC_SYNTAX.split(line)
                     if len(text) == 0:
@@ -118,7 +158,7 @@ class IncludePreprocessor(Preprocessor):
                             text[i] = text[i].rstrip('\r\n')
                             
                     text[0] = line_split[0] + text[0]
-                    text[-1] = text[-1] + line_split[2]
+                    text[-1] = text[-1] + line_split[5]
                     lines = lines[:loc] + text + lines[loc+1:]
                     break
                     


### PR DESCRIPTION
✨ Add support for specifying lines and line ranges.

For example:

```Markdown
{!filename!lines=1  3 8-10  2}
```

---

Thanks for this extension! It has been very useful, I use it to include all the examples for the docs for [FastAPI](https://fastapi.tiangolo.com/) and [Typer](https://typer.tiangolo.com/). :tada: 

That way I can test the same source files used in the documentation. :heavy_check_mark: 

Now I want to use this extra feature I'm proposing to include specific lines or line ranges, in particular for a new project I'm building, to be able to focus the reader's attention on a particular segment of a file. While still having a complete valid file shown at the end, that can be copied and run, because it's also part of the tests.

I'm using almost the same syntax used to highlight lines with [Material for MkDocs `hl_lines`](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#highlighting-specific-lines) `hl_lines="1  3 8-10  2"`.