### PR TITLE
Removed deprecated md_globals

### DIFF
--- a/markdown_include/include.py
+++ b/markdown_include/include.py
@@ -54,7 +54,7 @@ class MarkdownInclude(Extension):
         for key, value in configs.items():
             self.setConfig(key, value)
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         md.preprocessors.register(IncludePreprocessor(md,self.getConfigs()), 'include', 101)
 
 


### PR DESCRIPTION
`markdown` has removed this argument: https://github.com/Python-Markdown/markdown/blob/77fb7f1b51076becff488a9b42ef2883153262a0/docs/change_log/release-3.4.md#previously-deprecated-objects-have-been-removed